### PR TITLE
Fix parseXrpAmount - Divide by 1 million for XRP

### DIFF
--- a/lib/payment.js
+++ b/lib/payment.js
@@ -12,7 +12,7 @@ function Payment(msg) {
   this.validated = message.validated;
 
   function parseXrpAmount(drops) {
-    return parseFloat(drops) / 100000;
+    return parseFloat(drops) / 1000000;
   }
 
   if ((typeof message.transaction.Amount) == 'string') {


### PR DESCRIPTION
Fixed incorrect division in function parseXrpAmount(drops) ... need to divide by one million to get correct number of XRP.
